### PR TITLE
srewRate enabled for TraceLine, RunAsInstructed, RotateEV3

### DIFF
--- a/ms2021/appusr.hpp
+++ b/ms2021/appusr.hpp
@@ -137,9 +137,6 @@ extern Logger*      logger;
 #define COLOR_GREEN         5
 #define COLOR_WHITE         6
 
-#define C_INTERVAL    1       /* interval of changing pwd */
-#define C_PWD         1       /* chenge in pwd for interval time */
-
 enum BoardItem {
     LOCX, /* horizontal location    */
     LOCY, /* virtical   location    */


### PR DESCRIPTION
srewRate argument enabled for TraceLine, RunAsInstructed, RotateEV3.
MoveToLine class removed as combination of other general action classes can make an equivalent motion.