### PR TITLE
srewRate enabled for TraceLine, RunAsInstructed, RotateEV3

### DIFF
--- a/ms2021/app.cpp
+++ b/ms2021/app.cpp
@@ -280,6 +280,7 @@ public:
             leftMotor->setPWM(0.0);
             rightMotor->setPWM(0.0);
             updated = true;
+            return Status::Running;
         }
         int16_t deltaDegree = plotter->getDegree() - originalDegree;
         if (deltaDegree > 180) {

--- a/ms2021/appusr.hpp
+++ b/ms2021/appusr.hpp
@@ -137,9 +137,6 @@ extern Logger*      logger;
 #define COLOR_GREEN         5
 #define COLOR_WHITE         6
 
-#define C_INTERVAL    1       /* interval of changing pwd */
-#define C_PWD         1       /* chenge in pwd for interval time */
-
 enum BoardItem {
     LOCX, /* horizontal location    */
     LOCY, /* virtical   location    */


### PR DESCRIPTION
srewRate argument enabled for TraceLine, RunAsInstructed, RotateEV3.
RotateEV3 forces the robot to stop at the start of the motion.
MoveToLine class removed as combination of other general action classes can make an equivalent motion.